### PR TITLE
fix: cleaning up todo comments that were completed

### DIFF
--- a/internal/discord/moderation/moderation.go
+++ b/internal/discord/moderation/moderation.go
@@ -11,10 +11,6 @@ import (
 	"gorm.io/gorm"
 )
 
-// TODO:
-// - add some sort of system to reject enable/disable calls
-//   when they are in progress, prob some sort of mutex
-
 type ModerationConfig struct {
 	ImmuneRoles []string `json:"immune_roles"`
 }

--- a/internal/server/handler.auth.go
+++ b/internal/server/handler.auth.go
@@ -13,8 +13,6 @@ import (
 
 var sessionKey = "forkman-user-session"
 
-// TODO: use repository to insert into database instead of raw-doggin it
-
 // authLogin godoc
 //
 //	@summary Login with a provider


### PR DESCRIPTION
### TL;DR
Removed TODO comments from the codebase

### What changed?
Removed two TODO comments:
- Removed note about adding mutex for enable/disable calls in moderation system
- Removed note about using repository pattern for database operations in auth handler

### How to test?
No testing required as this is a documentation cleanup change

### Why make this change?
Improves code cleanliness by removing outdated or unnecessary TODO comments that were either implemented or no longer relevant to the project's direction